### PR TITLE
Add Variables for RetroAchievements

### DIFF
--- a/project/prefabs/triggers/bowserendfinaltrigger.gbsres
+++ b/project/prefabs/triggers/bowserendfinaltrigger.gbsres
@@ -42,6 +42,17 @@
       "children": {}
     },
     {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "79",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "d014e672-7942-4479-bd12-78af6bc43398"
+    },
+    {
       "command": "EVENT_IF",
       "args": {
         "condition": {

--- a/project/prefabs/triggers/bowserendtrigger.gbsres
+++ b/project/prefabs/triggers/bowserendtrigger.gbsres
@@ -42,6 +42,17 @@
       "children": {}
     },
     {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "79",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "923e7162-0612-4bea-bf88-5ed072e0d958"
+    },
+    {
       "command": "EVENT_IF",
       "args": {
         "condition": {

--- a/project/scenes/1-2/triggers/warpzone_trigger.gbsres
+++ b/project/scenes/1-2/triggers/warpzone_trigger.gbsres
@@ -26,6 +26,17 @@
         "y": 0
       },
       "id": "327a7128-4562-4eb7-8101-03c270e68060"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "10158cf4-0718-4d9d-8976-7100bea75c48"
     }
   ],
   "leaveScript": [],

--- a/project/scenes/4-2/triggers/warpzone_trigger.gbsres
+++ b/project/scenes/4-2/triggers/warpzone_trigger.gbsres
@@ -26,6 +26,17 @@
         "y": 0
       },
       "id": "4b190cd6-f427-4115-89aa-b11ba6137e60"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "3776318d-66b0-47be-9f18-8a75c8577d51"
     }
   ],
   "leaveScript": [],

--- a/project/scenes/9-2/triggers/warpzone_trigger.gbsres
+++ b/project/scenes/9-2/triggers/warpzone_trigger.gbsres
@@ -26,6 +26,17 @@
         "y": 0
       },
       "id": "540c9bed-5521-47aa-b8c1-94a92f0f9e33"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "973df5c6-6b40-44aa-b1ab-cfafe9a8f1db"
     }
   ],
   "leaveScript": [],

--- a/project/scenes/intermission/scene.gbsres
+++ b/project/scenes/intermission/scene.gbsres
@@ -35,6 +35,61 @@
   "y": 256,
   "script": [
     {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "74",
+        "value": {
+          "type": "variable",
+          "value": "9"
+        }
+      },
+      "id": "586b2c40-9263-4754-b88a-14566ab5945a"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "75",
+        "value": {
+          "type": "variable",
+          "value": "10"
+        }
+      },
+      "id": "bc2cf872-d5e5-4033-ae63-b5b6f3df586c"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "76",
+        "value": {
+          "type": "variable",
+          "value": "22"
+        }
+      },
+      "id": "c560eabe-b7f8-48a8-8d4e-ff70a3f8efeb"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 0
+        }
+      },
+      "id": "f3efdf13-ac83-4241-952d-38946ee89161"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "79",
+        "value": {
+          "type": "number",
+          "value": 0
+        }
+      },
+      "id": "5ee2c6ae-3c97-4550-a58e-4f2affd24044"
+    },
+    {
       "command": "EVENT_OVERLAY_HIDE",
       "args": {
         "__collapse": true

--- a/project/scenes/sublevel_8/triggers/warpzone_trigger.gbsres
+++ b/project/scenes/sublevel_8/triggers/warpzone_trigger.gbsres
@@ -26,6 +26,17 @@
         "y": 0
       },
       "id": "764edb9b-e398-4a54-a8ed-1341b9d487e1"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "53191d30-be26-4190-8ee5-0281b68daa7c"
     }
   ],
   "leaveScript": [],

--- a/project/scripts/changelevel.gbsres
+++ b/project/scripts/changelevel.gbsres
@@ -20,6 +20,17 @@
       "id": "a6c3cefe-f22b-4dd4-a465-c654ad6accfb"
     },
     {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "76",
+        "value": {
+          "type": "variable",
+          "value": "22"
+        }
+      },
+      "id": "edcad2ab-8390-4929-b70a-8ce9da3e408f"
+    },
+    {
       "command": "EVENT_IF",
       "args": {
         "condition": {

--- a/project/scripts/entercastle.gbsres
+++ b/project/scripts/entercastle.gbsres
@@ -47,6 +47,17 @@
     {
       "command": "EVENT_SET_VALUE",
       "args": {
+        "variable": "79",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "4eda88e4-2d01-4fcf-afe8-fa7b40838b34"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
         "variable": "43",
         "value": {
           "type": "expression",

--- a/project/scripts/initlevel.gbsres
+++ b/project/scripts/initlevel.gbsres
@@ -16,6 +16,61 @@
     {
       "command": "EVENT_SET_VALUE",
       "args": {
+        "variable": "74",
+        "value": {
+          "type": "variable",
+          "value": "9"
+        }
+      },
+      "id": "515cc747-2e12-45ca-8e7e-e5793ce91ac7"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "75",
+        "value": {
+          "type": "variable",
+          "value": "10"
+        }
+      },
+      "id": "c5d82d5e-2589-4fbc-bad8-cc75ce9d8c9a"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "76",
+        "value": {
+          "type": "variable",
+          "value": "22"
+        }
+      },
+      "id": "3dbbdafb-ae45-49fe-88a3-c000661d9b28"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "78",
+        "value": {
+          "type": "number",
+          "value": 0
+        }
+      },
+      "id": "d7d65d7b-21b6-4b81-97d3-521f5a9a9011"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "79",
+        "value": {
+          "type": "number",
+          "value": 0
+        }
+      },
+      "id": "c793d2e3-0bb5-42eb-b825-2ae8032ffe2c"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
         "variable": "73",
         "value": {
           "type": "variable",

--- a/project/scripts/togglepause.gbsres
+++ b/project/scripts/togglepause.gbsres
@@ -26,6 +26,17 @@
       "id": "fa833136-5139-4b23-87c7-a032a4a138db"
     },
     {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "77",
+        "value": {
+          "type": "number",
+          "value": 1
+        }
+      },
+      "id": "fb154d54-dee6-4e6f-a5b8-6cb924e91af1"
+    },
+    {
       "command": "EVENT_GBVM_SCRIPT",
       "args": {
         "script": "VM_MUSIC_MUTE 0b1111\nVM_SET_CONST_UINT8 _music_play_isr_pause, 1\nVM_MUSIC_MUTE 0b0000"
@@ -61,6 +72,17 @@
         "effect": 0
       },
       "id": "1611b1ac-a462-46be-983b-50dc041ccce6"
+    },
+    {
+      "command": "EVENT_SET_VALUE",
+      "args": {
+        "variable": "77",
+        "value": {
+          "type": "number",
+          "value": 0
+        }
+      },
+      "id": "07cc24aa-8c33-4112-9582-3f0dbbd73ab9"
     },
     {
       "command": "EVENT_GBVM_SCRIPT",

--- a/project/variables.gbsres
+++ b/project/variables.gbsres
@@ -385,6 +385,36 @@
       "id": "b2ca56b6-d305-439f-af15-3347127605a2__L0",
       "name": "Local 0",
       "symbol": "var_local_2"
+    },
+    {
+      "id": "74",
+      "name": "ActualWorld",
+      "symbol": "var_actualworld"
+    },
+    {
+      "id": "75",
+      "name": "ActualLevel",
+      "symbol": "var_actuallevel"
+    },
+    {
+      "id": "76",
+      "name": "ActualSubLevel",
+      "symbol": "var_actualsublevel"
+    },
+    {
+      "id": "77",
+      "name": "IsPaused",
+      "symbol": "var_ispaused"
+    },
+    {
+      "id": "78",
+      "name": "InWarpZone",
+      "symbol": "var_inwarpzone"
+    },
+    {
+      "id": "79",
+      "name": "LevelComplete",
+      "symbol": "var_levelcomplete"
     }
   ],
   "constants": [


### PR DESCRIPTION
I am working on a [RetroAchievements set](https://retroachievements.org/game/31200) for this game, memory addresses are read to unlock achievements and display the current state and statistics in rich presence. 
This PR adds additional variables that would allow for simpler achievement logic and more accurate Rich Presence. In my testing these work well for my purposes, but I want to make sure this is approved before I rewrite my logic to rely on these variables.

> ActualWorld
> ActualLevel

The CurrentWorld and CurrentLevel variables are changed on contact with warp triggers. These variables would allow me to accurately detect which world/level the player is in. These are set to CurrentWorld/CurrentLevel in InitLevel and Intermission

> ActualSubLevel

This serves the same purpose, but I noticed that later levels don't always set the CurrentSubLevel value when transitioning to different scenes. (Ex. 14-3-1 and 14-3-2 both set CurrentSubLevel to 0) I'm not sure if this is intended or if this variable goes unused here. For now I've left that alone and only added the variable - I think I'll be able to work around any issues with this.

> IsPaused

This allows me to detect when the player has paused the game to display a pause symbol on Rich Presence.

> InWarpZone

This simplifies detecting when the player has discovered a warp zone. This is attached to each warp zone trigger and is reset on InitLevel/Intermission

> LevelComplete

This is set to 1 when the player completes a level (CastleEnter, BowserEndTrigger/BowserEndFinalTrigger) and reset on InitLevel/Intermission

(I had warnings for line ending changes that I couldn't figure out a solution for, hopefully that doesn't cause any issues)